### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/KeyController.py
+++ b/KeyController.py
@@ -41,5 +41,5 @@ class KeyController:
 
 if __name__ == '__main__':
     kc = KeyController()
-    while kc.thread.isAlive():
+    while kc.thread.is_alive():
         print(kc.get_key_pressed())

--- a/simple_control.py
+++ b/simple_control.py
@@ -93,7 +93,7 @@ class SimpleTerminalController:
         self.change_color("BP_BuoyantActor", SHIP)
 
     def change_color(self, name, id):
-        success = self.client.simSetSegmentationObjectID(name + "[\w]*", id, True)
+        success = self.client.simSetSegmentationObjectID(name + r"[\w]*", id, True)
         print("Change of color on", name, "=", success)
 
     def takeoff(self):
@@ -235,7 +235,7 @@ class SimpleTerminalController:
         print("You entered the keyboard mode. Press 't' to return.")
         kc = KeyController()
         self.client.enableApiControl(True)
-        while kc.thread.isAlive():
+        while kc.thread.is_alive():
             self.client.cancelLastTask()
             self.client.enableApiControl(True)
             keys = kc.get_key_pressed()


### PR DESCRIPTION
Related to #1 

It also fixes a deprecation warning : 

```
find . -iname '*.py' | xargs -P4 -I{} python3.9 -Wall -m py_compile {}         
./simple_control.py:96: DeprecationWarning: invalid escape sequence \w
  success = self.client.simSetSegmentationObjectID(name + "[\w]*", id, True)
```